### PR TITLE
references: _toc.yml file added to notebook folder

### DIFF
--- a/notebooks/_toc.yml
+++ b/notebooks/_toc.yml
@@ -1,0 +1,2 @@
+format: jb-book
+root: english_language_learning_ability_prediction_analysis


### PR DESCRIPTION
I just added this file to the notebooks folder, It is apparently necessary for the references.bib file to work in Jupiter.