### PR TITLE
71 update environment and docker to include new issues at week 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,10 @@ FROM quay.io/jupyter/minimal-notebook:2023-11-21
 # docker build -t 522_project .
 # docker run --rm -p 8888:8888 -v $(pwd):/home/jovyan/work 522_project
 
-RUN conda install -y numpy=1.26.* \
-    pandas=2.1.* \
-    scikit-learn=1.3.* \
-    ipykernel=6.26.* \
-    altair=5.1.* \
-    matplotlib=3.8.* \
-    scipy=1.11.* \
-    jupyterlab=4.0.* \
-    jupyterlab-git=0.41.* \
-    click \
-    pickleshare=0.7 \
-    jupyter_contrib_nbextensions=0.7.0
+WORKDIR /home/jovyan
 
-RUN pip install "vegafusion[embed]" \
-    dataframe_image==0.2.2
+COPY environment.yml .
 
-EXPOSE 8888
+RUN conda env update --file environment.yml
+
+# EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR /home/jovyan
 
 COPY environment.yml .
 
-RUN conda env update --file environment.yml
+RUN conda env update -n base -f environment.yml
 
 # EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ RUN conda install -y numpy=1.26.* \
     matplotlib=3.8.* \
     scipy=1.11.* \
     jupyterlab=4.0.* \
-    jupyterlab-git=0.41.*
+    jupyterlab-git=0.41.* \
+    click \
+    pickleshare=0.7 \
+    jupyter_contrib_nbextensions=0.7.0
 
-RUN pip install "vegafusion[embed]"
+RUN pip install "vegafusion[embed]" \
+    dataframe_image==0.2.2
 
 EXPOSE 8888

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,5 @@
 services:
-  analysis-env:
+  analysis-nb-server:
     build:
       context: .
       dockerfile: Dockerfile

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   analysis-nb-server:
+    # image: farrandi/522-workflows-group-18
     build:
       context: .
       dockerfile: Dockerfile
@@ -7,5 +8,4 @@ services:
       - "8888:8888"
     volumes:
       - .:/home/jovyan/work
-    environment:
-      PASSWORD: password
+    platform: linux/amd64

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,11 @@
-name: "522"
+name: temp
 channels:
   - conda-forge
   - defaults
+  - anaconda
 dependencies:
   - altair=5.1
-  - click
+  - click=8.1
   - ipykernel=6.26
   - jupyter_contrib_nbextensions=0.7.0
   - jupyterlab-git=0.41
@@ -13,16 +14,14 @@ dependencies:
   - numpy=1.26
   - pandas=2.1
   - pickleshare=0.7
+  - pip=21.3
   - python=3.11
   - scikit-learn=1.3
   - scipy=1.11
-  - vega_datasets
-  - vegafusion
-  - vegafusion-jupyter
-  - vegafusion-python-embed
-  - vl-convert-python[version='>=0.14.0']
-  - pickleshare=0.7
-  - dataframe_image
+  - vl-convert-python=1.1
+  - vegafusion=1.4
+  - vegafusion-python-embed=1.4
+  - vegafusion-jupyter=1.4
+  - vega_datasets=0.9.0
   - pip:
       - dataframe-image==0.2.2
-prefix: /Users/farrandi/miniconda3/envs/522

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: temp
+name: "522"
 channels:
   - conda-forge
   - defaults
@@ -7,10 +7,12 @@ dependencies:
   - altair=5.1
   - click=8.1
   - ipykernel=6.26
+  - jupyter-book=0.15
   - jupyter_contrib_nbextensions=0.7.0
   - jupyterlab-git=0.41
   - jupyterlab=4.0
   - matplotlib=3.8
+  - myst-nb
   - numpy=1.26
   - pandas=2.1
   - pickleshare=0.7

--- a/environment.yml
+++ b/environment.yml
@@ -20,10 +20,15 @@ dependencies:
   - python=3.11
   - scikit-learn=1.3
   - scipy=1.11
-  - vl-convert-python=1.1
-  - vegafusion=1.4
-  - vegafusion-python-embed=1.4
-  - vegafusion-jupyter=1.4
-  - vega_datasets=0.9.0
+  # commenting below to prevent errors with docker build
+  # docker automatically installs these packages when installing altair
+  # - vl-convert-python=1.1
+  # - vegafusion=1.4
+  # - vegafusion-python-embed=1.4
+  # - vegafusion-jupyter=1.4
+  # - vega_datasets=0.9.0
   - pip:
       - dataframe-image==0.2.2
+      - vl-convert-python==1.1 # need this for docker build
+      - vegafusion==1.4.5
+      - vegafusion-python-embed==1.4.5


### PR DESCRIPTION
Running into a problem where I can create my conda environment locally via:

`conda env create -n 522 -f environment.yml`

But when trying to create docker image via command: `docker build -t 522 .`

Getting the error:

```
36.47 Could not solve for environment specs
36.47 The following packages are incompatible
36.47 ├─ vegafusion-jupyter 1.4**  is not installable because it requires
36.47 │  └─ vegafusion >=1.0 , which requires
36.47 │     └─ vegafusion-python-embed >=1.0 , which does not exist (perhaps a missing channel);
36.47 ├─ vegafusion-python-embed 1.4**  does not exist (perhaps a typo or a missing channel);
36.47 ├─ vegafusion 1.4** , which cannot be installed (as previously explained);
36.47 └─ vl-convert-python 1.1**  does not exist (perhaps a typo or a missing channel).
```